### PR TITLE
Patch 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "postinstall-build": "^5.0.1",
     "structured-source": "^3.0.2",
-    "textlint-plugin-html": "^0.1.7",
     "traverse": "^0.6.6",
     "yaml-ast-parser": "^0.0.40"
   },

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     "build": "babel -s -d lib src",
     "test": "mocha",
     "watch": "babel -w -s -d lib src",
-    "postinstall": "postinstall-build lib \"npm run build\""
+    "prepare": "npm run build"
   },
   "dependencies": {
-    "postinstall-build": "^5.0.1",
     "structured-source": "^3.0.2",
     "traverse": "^0.6.6",
     "yaml-ast-parser": "^0.0.40"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "postinstall-build lib \"npm run build\""
   },
   "dependencies": {
+    "postinstall-build": "^5.0.1",
     "structured-source": "^3.0.2",
     "traverse": "^0.6.6",
     "yaml-ast-parser": "^0.0.40"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "postinstall": "postinstall-build lib \"npm run build\""
   },
   "dependencies": {
-    "postinstall-build": "^5.0.1",
     "structured-source": "^3.0.2",
     "traverse": "^0.6.6",
     "yaml-ast-parser": "^0.0.40"


### PR DESCRIPTION
dependencies を更新しました。
- postinstall-build を使わない
- textlint-plugin-html はすでに使用されていない